### PR TITLE
guid support

### DIFF
--- a/include/modern_win32/com_exception.h
+++ b/include/modern_win32/com_exception.h
@@ -1,5 +1,5 @@
-﻿//
-// Copyright © 2020 Terry Moreland
+//
+// Copyright � 2020 Terry Moreland
 // Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), 
 // to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, 
 // and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
@@ -11,8 +11,38 @@
 // WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 // 
 
-#include <modern_win32/windows_exception.h>
-#include <modern_win32/threading/slim_lock.h>
-#include <modern_win32/threading/event.h>
-#include <modern_win32/null_handle.h>
-#include <modern_win32/invalid_handle.h>
+#ifndef __MODERN_WIN32_COM_EXCEPTION_H__
+#define __MODERN_WIN32_COM_EXCEPTION_H__
+#ifdef _WIN32
+
+#include <Windows.h>
+#include <exception>
+
+namespace modern_win32
+{
+    class com_exception final : public std::exception
+    {
+    public:
+        using native_handle_type = HRESULT;
+        explicit com_exception(HRESULT const result)
+            : exception()
+            , m_result(result)
+        {
+        }
+        explicit com_exception(HRESULT const result, char const* message)
+            : exception(message)
+            , m_result(result)
+        {
+        }
+
+        [[nodiscard]] native_handle_type get() const noexcept
+        {
+            return m_result;
+        }
+    private:
+        native_handle_type m_result;
+    };
+}
+
+#endif
+#endif

--- a/include/modern_win32/guid.h
+++ b/include/modern_win32/guid.h
@@ -1,0 +1,56 @@
+//
+// Copyright © 2020 Terry Moreland
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), 
+// to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, 
+// and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, 
+// WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// 
+
+#ifndef __MODERN_WIN32_GUID_H__
+#define __MODERN_WIN32_GUID_H__
+#include <ostream>
+#ifdef _WIN32
+
+
+#include <Windows.h>
+#include <string_view>
+
+namespace modern_win32
+{
+    class guid final
+    {
+    public:
+        explicit guid();
+        explicit guid(GUID const& value) noexcept;
+        explicit guid(char const* value);
+        explicit guid(wchar_t const* value);
+
+        [[nodiscard]] GUID get() const noexcept;
+
+        static guid& empty();
+
+        void swap(guid& other) noexcept;
+        [[nodiscard]] bool operator==(guid const& other) const noexcept;
+        [[nodiscard]] bool operator!=(guid const& other) const noexcept;
+
+        friend std::ostream& operator<<(std::ostream& os, const guid& obj);
+    private:
+        GUID m_value{};
+    };
+
+    [[nodiscard]] std::string to_string(guid const& uid);
+    void swap(guid& left, guid&right) noexcept;
+    [[nodiscard]] bool operator==(guid const& left, guid const& right) noexcept;
+    [[nodiscard]] bool operator!=(guid const& left, guid const& right) noexcept;
+
+    [[nodiscard]] guid new_guid() noexcept;
+
+}
+
+#endif
+#endif

--- a/include/modern_win32/guid.h
+++ b/include/modern_win32/guid.h
@@ -16,39 +16,36 @@
 #include <ostream>
 #ifdef _WIN32
 
-
 #include <Windows.h>
 #include <string_view>
+#include <modern_win32/modern_win32_export.h>
 
 namespace modern_win32
 {
     class guid final
     {
     public:
-        explicit guid();
-        explicit guid(GUID const& value) noexcept;
-        explicit guid(char const* value);
-        explicit guid(wchar_t const* value);
+        MODERN_WIN32_EXPORT explicit guid();
+        MODERN_WIN32_EXPORT explicit guid(GUID const& value) noexcept;
+        MODERN_WIN32_EXPORT explicit guid(char const* value);
+        MODERN_WIN32_EXPORT explicit guid(wchar_t const* value);
 
-        [[nodiscard]] GUID get() const noexcept;
+        MODERN_WIN32_EXPORT [[nodiscard]] GUID get() const noexcept;
 
-        static guid& empty();
+        MODERN_WIN32_EXPORT static guid& empty();
 
-        void swap(guid& other) noexcept;
-        [[nodiscard]] bool operator==(guid const& other) const noexcept;
-        [[nodiscard]] bool operator!=(guid const& other) const noexcept;
+        MODERN_WIN32_EXPORT void swap(guid& other) noexcept;
+        MODERN_WIN32_EXPORT [[nodiscard]] friend bool operator==(guid const& left, guid const& right) noexcept;
+        MODERN_WIN32_EXPORT [[nodiscard]] friend bool operator!=(guid const& left, guid const& right) noexcept;
 
         friend std::ostream& operator<<(std::ostream& os, const guid& obj);
     private:
         GUID m_value{};
     };
 
-    [[nodiscard]] std::string to_string(guid const& uid);
-    void swap(guid& left, guid&right) noexcept;
-    [[nodiscard]] bool operator==(guid const& left, guid const& right) noexcept;
-    [[nodiscard]] bool operator!=(guid const& left, guid const& right) noexcept;
-
-    [[nodiscard]] guid new_guid() noexcept;
+    MODERN_WIN32_EXPORT [[nodiscard]] std::string to_string(guid const& uid);
+    MODERN_WIN32_EXPORT void swap(guid& left, guid&right) noexcept;
+    MODERN_WIN32_EXPORT [[nodiscard]] guid new_guid() noexcept;
 
 }
 

--- a/include/modern_win32/naive_stack_allocator.h
+++ b/include/modern_win32/naive_stack_allocator.h
@@ -88,6 +88,11 @@ namespace modern_win32
         return false;
     }
 
+    template <typename TCHAR>
+    using naive_basic_string = std::basic_string<TCHAR, std::char_traits<TCHAR>, naive_stack_allocator<TCHAR, 64>>;
+    using naive_string = naive_basic_string<char>;
+    using naive_wstring = naive_basic_string<wchar_t>;
+
 }
 
 #endif

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -4,14 +4,17 @@ project(modern_win32 CXX)
 set(no_group_source_files
     "modern_win32/threading/slim_lock.cpp"
     "modern_win32/threading/thread.cpp"
+    "modern_win32/guid.cpp"
 )
 source_group("" FILES ${no_group_source_files})
 
 set(ALL_FILES ${no_group_source_files})
 
 set (ALL_HEADERS
+    "../include/modern_win32/com_exception.h"
     "../include/modern_win32/threading/event.h"
     "../include/modern_win32/invalid_handle.h"
+    "../include/modern_win32/guid.h"
     "../include/modern_win32/modern_win32_export.h"
     "../include/modern_win32/module_handle.h"
     "../include/modern_win32/naive_stack_allocator.h"

--- a/src/modern_win32/guid.cpp
+++ b/src/modern_win32/guid.cpp
@@ -1,0 +1,148 @@
+//
+// Copyright © 2020 Terry Moreland
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), 
+// to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, 
+// and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, 
+// WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// 
+
+#include <modern_win32/guid.h>
+#include <algorithm>
+#include <memory>
+#include <modern_win32/com_exception.h>
+#include <modern_win32/module_handle.h>
+
+namespace modern_win32
+{
+
+template <typename TCHAR>
+GUID from_string(TCHAR const* value, char const* method_name)
+{
+    if (value == nullptr)
+        throw std::invalid_argument("value is null");
+
+    auto const maybe_shell32 = get_module("Shell32.dll");
+    if (!maybe_shell32.has_value())
+        throw std::runtime_error("Unable to load Shell32.dll");
+
+    using guid_from_string = BOOL (WINAPI *)(TCHAR const*, LPGUID);
+    auto const& shell32 = maybe_shell32.value();
+    auto const guid_from_string_delegate = reinterpret_cast<guid_from_string>(GetProcAddress(shell32.get(), method_name));
+    if (guid_from_string_delegate == nullptr)
+        throw std::runtime_error("GUIDFromString method not found");
+
+    GUID output;
+    if (guid_from_string_delegate(value, &output) != TRUE)
+        throw std::invalid_argument("Unable to parse value into GUID");
+
+    return output;
+}
+
+
+guid::guid() 
+    : m_value(empty().get())
+{
+    if (auto const hr = CoCreateGuid(&m_value); FAILED(hr)) 
+        throw com_exception(hr);
+}
+
+guid::guid(GUID const& value) noexcept
+    : m_value(value)
+{
+}
+
+guid::guid(char const* value)
+{
+    if (value == nullptr)
+        throw std::invalid_argument("value is null");
+
+    m_value = from_string(value, "GUIDFromStringA");
+}
+guid::guid(wchar_t const* value)
+{
+    if (value == nullptr)
+        throw std::invalid_argument("value is null");
+    m_value = from_string(value, "GUIDFromStringW");
+
+}
+
+guid& guid::empty()
+{
+    static guid empty{};
+    return empty;
+}
+
+GUID guid::get() const noexcept
+{
+    return m_value;
+}
+
+void guid::swap(guid& other) noexcept
+{
+    std::swap(m_value, other.m_value);
+}
+
+bool guid::operator==(guid const& other) const noexcept
+{
+    return m_value == other.m_value;
+}
+bool guid::operator!=(guid const& other) const noexcept
+{
+    return !operator==(other);
+}
+
+std::wstring to_wstring(guid const& uid)
+{
+    std::wstring value{};
+    value.reserve(std::size(L"00000000-0000-0000-0000-000000000000"));
+    if (StringFromGUID2(uid.get(), &value[0], static_cast<int>(value.size())) == 0)
+        return L"********-****-****-****-************";
+    return value;
+}
+std::string to_string(guid const& uid)
+{
+    auto value = to_wstring(uid);
+    std::string value_a{};
+
+
+    std::transform(std::begin(value), std::end(value), std::back_inserter(value_a),
+        [](auto const& wide_char) {
+            const wchar_t ascii_upper_bound = 127;
+            const wchar_t ascii_lower_bound = 0;
+            return wide_char > ascii_upper_bound || wide_char < ascii_lower_bound
+                ? '?'
+                : static_cast<char>(wide_char);
+        });
+    return "";
+}
+void swap(guid& left, guid&right) noexcept
+{
+    left.swap(right);
+}
+bool operator==(guid const& left, guid const& right) noexcept
+{
+    return left.operator==(right);
+}
+
+bool operator!=(guid const& left, guid const& right) noexcept
+{
+    return left.operator!=(right);
+}
+std::ostream& operator<<(std::ostream& os, const guid& obj)
+{
+    return os << to_string(obj);
+}
+
+[[nodiscard]] guid new_guid() noexcept
+{
+    return guid();
+}
+
+
+
+}

--- a/tests/modern_win32_test/CMakeLists.txt
+++ b/tests/modern_win32_test/CMakeLists.txt
@@ -11,7 +11,7 @@ add_executable(${TEST_PROJECT_NAME} ${TEST_SOURCES}
     "slim_lock_test.cpp" 
     "context.cpp" 
     "thread_test.cpp"
-)
+ "guid_test.cpp")
 
 add_test(NAME ${TEST_PROJECT_NAME} COMMAND ${TEST_PROJECT_NAME})
 

--- a/tests/modern_win32_test/guid_test.cpp
+++ b/tests/modern_win32_test/guid_test.cpp
@@ -1,0 +1,72 @@
+//
+// Copyright © 2020 Terry Moreland
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), 
+// to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, 
+// and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, 
+// WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// 
+
+#pragma warning(push, 2)
+#include <gtest/gtest.h>
+#pragma warning(pop)
+#include <modern_win32/guid.h>
+#include "context.h"
+
+using modern_win32::guid;
+
+TEST(guid, constructor_no_throw_when_string_valid)
+{
+    char const* value = "83066E5E-D9FE-40D2-B68C-548B2131B65C";
+    ASSERT_NO_THROW({guid id(value);});
+}
+TEST(guid, constructor_throw_when_string_nullptr)
+{
+    char const* value = nullptr;
+    ASSERT_THROW({guid id(value);}, std::invalid_argument);
+}
+TEST(guid, constructor_no_throw_when_wide_string_valid)
+{
+    wchar_t const* value = L"83066E5E-D9FE-40D2-B68C-548B2131B65C";
+    ASSERT_NO_THROW({guid id(value);});
+}
+TEST(guid, constructor_throw_when_wide_string_nullptr)
+{
+    wchar_t const* value = nullptr;
+    ASSERT_THROW({guid id(value);}, std::invalid_argument);
+}
+TEST(guid, constructor_throw_when_string_invalid)
+{
+    char const* value = "invalid guid";
+    ASSERT_THROW({guid id(value);}, std::invalid_argument);
+}
+TEST(guid, constructor_throw_when_wide_string_invalid)
+{
+    wchar_t const* value = L"invalid guid";
+    ASSERT_THROW({guid id(value);}, std::invalid_argument);
+}
+
+TEST(guid, equals_returns_true_for_matching_values)
+{
+    char const* value = "83066E5E-D9FE-40D2-B68C-548B2131B65C";
+    guid const id_one(value);
+    guid const id_two(value);
+
+    bool const are_equal = id_one == id_two;
+
+    ASSERT_TRUE(are_equal);
+}
+
+TEST(guid, equals_returns_false_for_non_matching_values)
+{
+    guid const id_one("83066E5E-D9FE-40D2-B68C-548B2131B65C");
+    guid const id_two("6CCE5066-427E-4B32-AA77-DEDA5519F786");
+
+    bool const are_equal = id_one == id_two;
+
+    ASSERT_FALSE(are_equal);
+}

--- a/tests/modern_win32_test/thread_test.cpp
+++ b/tests/modern_win32_test/thread_test.cpp
@@ -142,3 +142,40 @@ TEST(thread, start_launches_unique_anonymous_thread_start)
     ASSERT_TRUE(ctx.complete && !ctx.get_timed_out());
 }
 
+TEST(thread, set_thread_updates_description)
+{
+    // arrange
+    std::wstring const expected_name{L"set_thread_updates_description"};
+    EXPECT_TRUE(set_thread_name(GetCurrentThread(), expected_name.c_str()));
+
+    // act
+    PWSTR actual_name{};
+    EXPECT_TRUE(SUCCEEDED(GetThreadDescription(GetCurrentThread(), &actual_name)));
+
+    // assert
+    ASSERT_EQ(expected_name, actual_name);
+}
+
+TEST(thread, get_thread_name_returns_value)
+{
+    // arrange
+    std::wstring const expected_name{L"get_thread_name_returns_value"};
+    EXPECT_TRUE(SUCCEEDED(SetThreadDescription(GetCurrentThread(), expected_name.c_str())));
+
+    // act
+    auto const maybe_actual_name = get_thread_name(GetCurrentThread());
+
+    ASSERT_TRUE(maybe_actual_name.has_value());
+}
+
+TEST(thread, get_thread_name_returns_correct_value)
+{
+    // arrange
+    std::wstring const expected_name{L"get_thread_name_returns_correct_value-name"};
+    EXPECT_TRUE(SUCCEEDED(SetThreadDescription(GetCurrentThread(), expected_name.c_str())));
+
+    // act
+    auto const maybe_actual_name = get_thread_name(GetCurrentThread());
+
+    ASSERT_EQ(expected_name, maybe_actual_name.value());
+}


### PR DESCRIPTION
## Description

- first pass at wrapper around GUID
- added com_exception, a simpler variation of _com_error that doesn't have the extended error info
- additional thread tests for veriify get/set thread name
- updated guid to export methods
- added naive_string and naive_wstring to naive_stack_allocator