### PR TITLE
Minor updates

### DIFF
--- a/CMakeSettings.json
+++ b/CMakeSettings.json
@@ -35,6 +35,30 @@
                     "type": "FILEPATH"
                 }
             ]
+        },
+        {
+            "name": "x64-Clang-Debug",
+            "generator": "Ninja",
+            "configurationType": "Debug",
+            "buildRoot": "${projectDir}\\out\\build\\${name}",
+            "installRoot": "${projectDir}\\out\\install\\${name}",
+            "cmakeCommandArgs": "",
+            "buildCommandArgs": "",
+            "ctestCommandArgs": "",
+            "inheritEnvironments": [ "clang_cl_x64_x64" ],
+            "variables": []
+        },
+        {
+            "name": "x64-Clang-Release",
+            "generator": "Ninja",
+            "configurationType": "RelWithDebInfo",
+            "buildRoot": "${projectDir}\\out\\build\\${name}",
+            "installRoot": "${projectDir}\\out\\install\\${name}",
+            "cmakeCommandArgs": "",
+            "buildCommandArgs": "",
+            "ctestCommandArgs": "",
+            "inheritEnvironments": [ "clang_cl_x64_x64" ],
+            "variables": []
         }
     ]
 }

--- a/include/modern_win32/guid.h
+++ b/include/modern_win32/guid.h
@@ -58,9 +58,9 @@ namespace modern_win32
         GUID m_value{};
     };
 
-    MODERN_WIN32_EXPORT [[nodiscard]] std::string to_string(guid const& uid);
+    [[nodiscard]] MODERN_WIN32_EXPORT std::string to_string(guid const& uid);
     MODERN_WIN32_EXPORT void swap(guid& left, guid&right) noexcept;
-    MODERN_WIN32_EXPORT [[nodiscard]] guid new_guid() noexcept;
+    [[nodiscard]] MODERN_WIN32_EXPORT guid new_guid() noexcept;
 
 }
 

--- a/include/modern_win32/guid.h
+++ b/include/modern_win32/guid.h
@@ -22,23 +22,38 @@
 
 namespace modern_win32
 {
-    class guid final
+    class MODERN_WIN32_EXPORT guid final
     {
     public:
-        MODERN_WIN32_EXPORT explicit guid();
-        MODERN_WIN32_EXPORT explicit guid(GUID const& value) noexcept;
-        MODERN_WIN32_EXPORT explicit guid(char const* value);
-        MODERN_WIN32_EXPORT explicit guid(wchar_t const* value);
+        explicit guid();
+        explicit guid(GUID const& value) noexcept;
+        explicit guid(char const* value);
+        explicit guid(wchar_t const* value);
 
-        MODERN_WIN32_EXPORT [[nodiscard]] GUID get() const noexcept;
+        [[nodiscard]] GUID get() const noexcept;
 
-        MODERN_WIN32_EXPORT static guid& empty();
+        static guid& empty();
 
-        MODERN_WIN32_EXPORT void swap(guid& other) noexcept;
-        MODERN_WIN32_EXPORT [[nodiscard]] friend bool operator==(guid const& left, guid const& right) noexcept;
-        MODERN_WIN32_EXPORT [[nodiscard]] friend bool operator!=(guid const& left, guid const& right) noexcept;
+        void swap(guid& other) noexcept;
+        MODERN_WIN32_EXPORT friend bool operator==(guid const& left, guid const& right) noexcept;
+        MODERN_WIN32_EXPORT friend bool operator!=(guid const& left, guid const& right) noexcept;
+
+        MODERN_WIN32_EXPORT friend bool operator==(GUID const& left, guid const& right) noexcept;
+        MODERN_WIN32_EXPORT friend bool operator!=(GUID const& left, guid const& right) noexcept;
+
+        MODERN_WIN32_EXPORT friend bool operator==(guid const& left, GUID const& right) noexcept;
+        MODERN_WIN32_EXPORT friend bool operator!=(guid const& left, GUID const& right) noexcept;
 
         friend std::ostream& operator<<(std::ostream& os, const guid& obj);
+
+        explicit operator GUID() const
+        {
+            return m_value;
+        }
+        explicit operator bool() const
+        {
+            return *this != empty();
+        }
     private:
         GUID m_value{};
     };

--- a/include/modern_win32/threading/slim_lock.h
+++ b/include/modern_win32/threading/slim_lock.h
@@ -33,48 +33,48 @@ namespace modern_win32::threading
     /// modern C++ wrapper around SRWLOCK intended to mirror std::shared_mutex such that it be used by both
     /// std::lock_guard and std::shared_lock to provide RAII release of the lock
     /// </summary>
-    class slim_lock final
+    class MODERN_WIN32_EXPORT slim_lock final
     {
         using native_handle_type = PSRWLOCK;
 
     public:
-        MODERN_WIN32_EXPORT explicit slim_lock();
-        MODERN_WIN32_EXPORT slim_lock(slim_lock const&) = delete;
-        MODERN_WIN32_EXPORT slim_lock(slim_lock&& other) noexcept;
+        explicit slim_lock();
+        slim_lock(slim_lock const&) = delete;
+        slim_lock(slim_lock&& other) noexcept;
         ~slim_lock() noexcept = default;
 
         /// <summary>
         /// Acquires a slim reader/writer (SRW) lock in exclusive mode.
         /// </summary>
-        MODERN_WIN32_EXPORT void lock() noexcept;
+        void lock() noexcept;
 
         /// <summary>
         /// Attempts to acquire a slim reader/writer (SRW) lock in exclusive mode. If the call is successful, the calling thread takes ownership of the lock.
         /// </summary>
         /// <returns>true if lock has been obtained; otherwise, false</returns>
-        [[nodiscard]] MODERN_WIN32_EXPORT bool try_lock() noexcept;
+        [[nodiscard]] bool try_lock() noexcept;
 
         /// <summary>
         /// Releases an SRW lock that was opened in exclusive mode.
         /// </summary>
-        MODERN_WIN32_EXPORT void unlock() noexcept;
+        void unlock() noexcept;
 
         /// <summary>
         /// Acquires an SRW lock in shared mode.
         /// </summary>
-        MODERN_WIN32_EXPORT void lock_shared() noexcept;
+        void lock_shared() noexcept;
 
         /// <summary>
         /// Attempts to acquire a slim reader/writer (SRW) lock in shared mode. If the call is successful, the calling thread takes ownership of the lock.
         /// </summary>
         /// <returns>true if lock has been obtained; otherwise, false</returns>
-        [[nodiscard]] MODERN_WIN32_EXPORT bool try_lock_shared() noexcept;
+        [[nodiscard]] bool try_lock_shared() noexcept;
 
         /// <summary>
         /// Releases an SRW lock that was opened in shared mode.
         /// </summary>
         /// <returns></returns>
-        MODERN_WIN32_EXPORT void unlock_shared() noexcept;
+        void unlock_shared() noexcept;
 
         /// <summary>
         /// returns the underlying implementation-defined native handle object
@@ -82,7 +82,7 @@ namespace modern_win32::threading
         [[nodiscard]] native_handle_type native_handle() noexcept;
 
         slim_lock& operator=(slim_lock const&) = delete;
-        MODERN_WIN32_EXPORT slim_lock& operator=(slim_lock&& other) noexcept;
+        slim_lock& operator=(slim_lock&& other) noexcept;
 
     private:
         SRWLOCK m_lock{};

--- a/include/modern_win32/threading/thread.h
+++ b/include/modern_win32/threading/thread.h
@@ -53,7 +53,7 @@ namespace modern_win32::threading
     /// <remarks>only works on Windows Server 2016+ or Windows 10 1607+</remarks>
     [[nodiscard]] MODERN_WIN32_EXPORT std::optional<std::wstring> get_thread_name(thread_handle::native_handle_type const handle);
 
-    class thread final
+    class MODERN_WIN32_EXPORT thread final
     {
     public:
         using native_handle_type = typename thread_handle::native_handle_type;
@@ -63,10 +63,10 @@ namespace modern_win32::threading
         using thread_proc = DWORD (*)(thread_parameter);
         using native_thread_id = DWORD;
 
-        MODERN_WIN32_EXPORT explicit thread(std::unique_ptr<thread_start> worker);
-        MODERN_WIN32_EXPORT explicit thread(modern_handle_type&& handle);
-        MODERN_WIN32_EXPORT explicit thread(native_handle_type const& handle = thread_handle::invalid());
-        MODERN_WIN32_EXPORT thread(thread&& other) noexcept;
+        explicit thread(std::unique_ptr<thread_start> worker);
+        explicit thread(modern_handle_type&& handle);
+        explicit thread(native_handle_type const& handle = thread_handle::invalid());
+        thread(thread&& other) noexcept;
         thread(thread const&) = delete;
         ~thread() = default;
 
@@ -76,7 +76,7 @@ namespace modern_win32::threading
         /// <param name="name">the name to apply to the thread represented by this object</param>
         /// <returns>true on success; otherwise, false</returns>
         /// <remarks>only works on Windows Server 2016+ or Windows 10 1607+</remarks>
-        [[nodiscard]] MODERN_WIN32_EXPORT bool set_name(wchar_t const* name) const;
+        [[nodiscard]] bool set_name(wchar_t const* name) const;
 
         /// <summary>
         /// Sets the description (or name) of the thread represented by this objet to <parmref name="name"/>
@@ -84,14 +84,14 @@ namespace modern_win32::threading
         /// <param name="name">the name to apply to the thread represented by this object</param>
         /// <returns>true on success; otherwise, false</returns>
         /// <remarks>only works on Windows Server 2016+ or Windows 10 1607+</remarks>
-        [[nodiscard]] MODERN_WIN32_EXPORT bool set_name(char const* name) const;
+        [[nodiscard]] bool set_name(char const* name) const;
 
         /// <summary>
         /// returns the current name for the thread represented by this object
         /// </summary>
         /// <returns>optional containing the thread name on success; otherwise <see cref="std::nullopt"/></returns>
         /// <remarks>only works on Windows Server 2016+ or Windows 10 1607+</remarks>
-        [[nodiscard]] MODERN_WIN32_EXPORT std::optional<std::wstring> get_name() const;
+        [[nodiscard]] std::optional<std::wstring> get_name() const;
 
         /// <summary>
         /// starts the thread using <paramref name="worker"/> if not already running
@@ -118,7 +118,7 @@ namespace modern_win32::threading
         /// <param name="worker">method to execute in new thread, must return DWORD and take thread_parameter</param>
         /// <param name="parameter">parameter to use in thread creation</param>
         /// <returns>true if thread is started; otherwise, false</returns>
-        [[nodiscard]] MODERN_WIN32_EXPORT bool start(thread_proc const worker, thread_parameter const parameter);
+        [[nodiscard]] bool start(thread_proc const worker, thread_parameter const parameter);
 
         /// <summary>
         /// starts the thread using <paramref name="worker"/> if not already running
@@ -128,38 +128,41 @@ namespace modern_win32::threading
         /// <remarks>
         /// thread does not maintain lifetime of thread_start it is up to the caller to ensure that object exists until the thread completes
         /// </remarks>
-        [[nodiscard]] MODERN_WIN32_EXPORT bool start(thread_start* const worker);
+        [[nodiscard]] bool start(thread_start* const worker);
 
         /// <summary>
         /// starts the thread usnig provided thread_start
         /// </summary>
         /// <returns>true if thread is started; otherwise, false</returns>
-        [[nodiscard]] MODERN_WIN32_EXPORT bool start();
+        [[nodiscard]] bool start();
 
         /// <summary>
         /// Blocks the calling thread until the thread represented by this instance terminates.
         /// </summary>
-        MODERN_WIN32_EXPORT void join() const;
+        void join() const;
 
         /// <summary>
         /// Blocks the calling thread until the thread represented by this instance terminates
         /// or the specified time elapses
         /// </summary>
-        [[nodiscard]] MODERN_WIN32_EXPORT bool join(std::chrono::milliseconds const& timeout) const;
+        [[nodiscard]] bool join(std::chrono::milliseconds const& timeout) const;
 
         /// <summary>
         /// returns running state of the thread represented by this object
         /// </summary>
         /// <returns>true if thread is still active; otherwise, false</returns>
         /// <exception cref="windows_exceptionl">thrown if Win32 API GetExitCodeThread returns zero</exception>
-        [[nodiscard]] MODERN_WIN32_EXPORT bool is_running() const;
+        [[nodiscard]] bool is_running() const;
 
         thread& operator=(thread const&) = delete;
-        MODERN_WIN32_EXPORT thread& operator=(thread&& other) noexcept; 
+        thread& operator=(thread&& other) noexcept; 
     private:
+#       pragma warning(push)
+#       pragma warning(disable : 4251)
         modern_handle_type m_handle{};
         native_thread_id m_thread_id{};
         std::unique_ptr<thread_start> m_thread_start;
+#       pragma warning(pop)
 
         static DWORD __stdcall thread_adapter(void* state);
     };

--- a/src/modern_win32/guid.cpp
+++ b/src/modern_win32/guid.cpp
@@ -50,7 +50,7 @@ guid::guid(char const* value)
     if (value == nullptr)
         throw std::invalid_argument("value is null");
 
-    using char_type = typename std::remove_pointer<RPC_CSTR>::type;
+    using char_type = std::remove_pointer<RPC_CSTR>::type;
     char_type buffer[64]{};
     memcpy_s(buffer, sizeof(buffer), value, strlen(value)*sizeof(char_type));
     buffer[63] = '\0';
@@ -65,7 +65,7 @@ guid::guid(wchar_t const* value)
     if (value == nullptr)
         throw std::invalid_argument("value is null");
 
-    using char_type = typename std::remove_pointer<RPC_WSTR>::type;
+    using char_type = std::remove_pointer<RPC_WSTR>::type;
     char_type buffer[64]{};
     memcpy_s(buffer, sizeof(buffer), value, wcslen(value)*sizeof(char_type));
     buffer[63] = '\0';
@@ -129,6 +129,26 @@ bool operator!=(guid const& left, guid const& right) noexcept
 {
     return left.m_value != right.m_value;
 }
+
+bool operator==(GUID const& left, guid const& right) noexcept
+{
+    return left == right.m_value;
+}
+
+bool operator!=(GUID const& left, guid const& right) noexcept
+{
+    return left != right.m_value;
+}
+bool operator==(guid const& left, GUID const& right) noexcept
+{
+    return left.m_value == right;
+}
+
+bool operator!=(guid const& left, GUID const& right) noexcept
+{
+    return left.m_value != right;
+}
+
 std::ostream& operator<<(std::ostream& os, const guid& obj)
 {
     return os << to_string(obj);


### PR DESCRIPTION
## Description

- moved MODERN_WIN32_EXPORT from specific methods to class level
- suppressed C4251 generated from stl classes being exported
- moved [[nodiscard]] position in guid.h to resolve clang error