### PR TITLE
Wait duration rework

### DIFF
--- a/include/modern_win32/shared/chrono_extensions.h
+++ b/include/modern_win32/shared/chrono_extensions.h
@@ -1,0 +1,71 @@
+//
+// Copyright © 2020 Terry Moreland
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), 
+// to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, 
+// and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, 
+// WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// 
+
+#ifndef MODERN_WIN32_SHARED_CHRONO_EXTENSIONS_H_
+#define MODERN_WIN32_SHARED_CHRONO_EXTENSIONS_H_
+
+#include <chrono>
+
+namespace modern_win32::shared
+{
+
+    /// <summary>
+    /// converts value to duration in milliseconds
+    /// </summary>
+    /// <typeparam name="REP">
+    /// an arithmetic type representing the number of ticks
+    /// </typeparam>
+    /// <typeparam name="PERIOD">
+    /// Period (until C++17)typename Period::type (since C++17), a std::ratio
+    /// representing the tick period (i.e. the number of seconds per tick)
+    /// </typeparam>
+    /// <param name="value">value to convert</param>
+    /// <returns>value as duration in milliseconds</returns>
+    /// <remarks>
+    /// conversion from smaller period will result in loss of precision
+    /// </remarks>
+    template <class REP, class PERIOD>
+    [[nodiscard]]
+    constexpr auto to_milliseconds(std::chrono::duration<REP, PERIOD> value) ->
+        std::chrono::duration<REP, PERIOD>
+    {
+        return std::chrono::duration_cast<std::chrono::milliseconds>(value);
+    }
+
+    /// <summary>
+    /// converts value to duration in milliseconds
+    /// </summary>
+    /// <typeparam name="REP">
+    /// an arithmetic type representing the number of ticks
+    /// </typeparam>
+    /// <typeparam name="PERIOD">
+    /// Period (until C++17)typename Period::type (since C++17), a std::ratio
+    /// representing the tick period (i.e. the number of seconds per tick)
+    /// </typeparam>
+    /// <param name="value">value to convert</param>
+    /// <returns>value as duration in milliseconds</returns>
+    /// <remarks>
+    /// conversion from smaller period will result in loss of precision
+    /// </remarks>
+    template <class REP, class PERIOD>
+    [[nodiscard]]
+    constexpr auto to_seconds(std::chrono::duration<REP, PERIOD> value) ->
+        std::chrono::duration<REP, PERIOD>
+    {
+        return std::chrono::duration_cast<std::chrono::milliseconds>(value);
+    }
+
+}
+
+
+#endif

--- a/include/modern_win32/shared/chrono_extensions.h
+++ b/include/modern_win32/shared/chrono_extensions.h
@@ -37,7 +37,7 @@ namespace modern_win32::shared
     template <class REP, class PERIOD>
     [[nodiscard]]
     constexpr auto to_milliseconds(std::chrono::duration<REP, PERIOD> value) ->
-        std::chrono::duration<REP, PERIOD>
+        std::chrono::milliseconds
     {
         return std::chrono::duration_cast<std::chrono::milliseconds>(value);
     }
@@ -60,9 +60,9 @@ namespace modern_win32::shared
     template <class REP, class PERIOD>
     [[nodiscard]]
     constexpr auto to_seconds(std::chrono::duration<REP, PERIOD> value) ->
-        std::chrono::duration<REP, PERIOD>
+        std::chrono::seconds
     {
-        return std::chrono::duration_cast<std::chrono::milliseconds>(value);
+        return std::chrono::duration_cast<std::chrono::seconds>(value);
     }
 
 }

--- a/include/modern_win32/threading/event.h
+++ b/include/modern_win32/threading/event.h
@@ -79,10 +79,29 @@ namespace modern_win32::threading
         /// <param name="alertable">if true wait can be interupted by alerts</param>
         /// <returns>true if event was signaled; otherwise, false</returns>
         /// <exception cref="windows_exception">if wait fails</exception>
+        template <class REP = long long, class PERIOD = std::milli>
         [[nodiscard]]
-        bool wait_one(std::chrono::milliseconds const timeout = get_infinity_in_ms(), bool const alertable = false) const 
+        bool wait_one(std::optional<std::chrono::duration<REP, PERIOD>> const timeout = std::nullopt, bool const alertable = false) const 
         {
             return is_complete(modern_win32::wait_one(event_, timeout, alertable));
+        }
+
+        /// <summary>
+        /// wait for event to be signaled
+        /// </summary>
+        /// <param name="timeout">
+        /// The time-out interval, in milliseconds. If a nonzero value is specified, the function waits until the specified objects are signaled or the interval elapses.
+        /// If  zero, the function does not enter a wait state if the specified objects are not signaled; it always returns immediately.
+        /// If maximum value or maximum value of DWORD, the function will return only when the specified objects are signaled.
+        /// </param>
+        /// <param name="alertable">if true wait can be interupted by alerts</param>
+        /// <returns>true if event was signaled; otherwise, false</returns>
+        /// <exception cref="windows_exception">if wait fails</exception>
+        template <class REP = long long, class PERIOD = std::milli>
+        [[nodiscard]]
+        bool wait_one(std::chrono::duration<REP, PERIOD> const timeout = std::nullopt, bool const alertable = false) const 
+        {
+            return wait_one(std::optional(timeout, alertable));
         }
 
         /// <summary>

--- a/include/modern_win32/threading/event.h
+++ b/include/modern_win32/threading/event.h
@@ -99,9 +99,9 @@ namespace modern_win32::threading
         /// <exception cref="windows_exception">if wait fails</exception>
         template <class REP = long long, class PERIOD = std::milli>
         [[nodiscard]]
-        bool wait_one(std::chrono::duration<REP, PERIOD> const timeout = std::nullopt, bool const alertable = false) const 
+        bool wait_one(std::chrono::duration<REP, PERIOD> const timeout, bool const alertable = false) const 
         {
-            return wait_one(std::optional(timeout, alertable));
+            return wait_one(std::optional(timeout), alertable);
         }
 
         /// <summary>

--- a/include/modern_win32/threading/semaphore.h
+++ b/include/modern_win32/threading/semaphore.h
@@ -58,8 +58,9 @@ namespace modern_win32::threading
         /// </param>
         /// <returns>true if event was signaled; otherwise, false</returns>
         /// <exception cref="windows_exception">if wait fails</exception>
+        template <class REP = long long, class PERIOD = std::milli>
         [[nodiscard]]
-        bool wait_one(std::chrono::milliseconds const timeout = get_infinity_in_ms()) const 
+        bool wait_one(std::optional<std::chrono::duration<REP, PERIOD>> const timeout = std::nullopt) const 
         {
             return is_complete(modern_win32::wait_one(handle_, timeout));
         }

--- a/include/modern_win32/wait_for.h
+++ b/include/modern_win32/wait_for.h
@@ -74,13 +74,14 @@ namespace modern_win32
     constexpr auto to_numeric_milliseconds(std::chrono::duration<REP, PERIOD> const& timeout) -> NUMERIC
     {
         static_assert(std::is_arithmetic_v<NUMERIC>);
+        // extra set of () around std::numeric_limits<>::max to circumvent windows max macro
+        static_assert((std::numeric_limits<NUMERIC>::max)() <= (std::numeric_limits<std::chrono::milliseconds::rep>::max)());
 
         using std::chrono::milliseconds;
-        using millisecond_rep = decltype(std::declval<milliseconds>().count());
-        // extra set of () around std::numeric_limits<>::max to circumvent windows max macro
         using modern_win32::shared::to_milliseconds;
 
-        return to_milliseconds(timeout) > milliseconds(static_cast<millisecond_rep>((std::numeric_limits<NUMERIC>::max)()))
+        auto const timeout_in_milliseconds = to_milliseconds(timeout);
+        return timeout_in_milliseconds.count() >= static_cast<std::chrono::milliseconds::rep>((std::numeric_limits<NUMERIC>::max)())
             ? (std::numeric_limits<NUMERIC>::max)()
             : static_cast<NUMERIC>(timeout.count());
     }

--- a/include/modern_win32/wait_for.h
+++ b/include/modern_win32/wait_for.h
@@ -20,7 +20,7 @@
 #include <optional>
 #include <modern_win32/wait_for_result.h>
 #include <modern_win32/modern_win32_export.h>
-#include <modern_win32/windows_exception.h>
+#include <modern_win32/shared/chrono_extensions.h>
 
 namespace modern_win32
 {
@@ -52,22 +52,35 @@ namespace modern_win32
         }
     }
 
-    constexpr auto get_infinity_in_ms() -> std::chrono::duration<long long>
+    /// <summary>
+    /// convert timeout to time in milliseconds as NUMERIC type if less than
+    /// maximum value of NUMERIC; otherwise, maximum value 
+    /// </summary>
+    /// <typeparam name="NUMERIC">NUMERIC type to convert to</typeparam>
+    /// <typeparam name="REP">
+    /// an arithmetic type representing the number of ticks
+    /// </typeparam>
+    /// <typeparam name="PERIOD">
+    /// Period (until C++17)typename Period::type (since C++17), a std::ratio
+    /// representing the tick period (i.e. the number of seconds per tick)
+    /// </typeparam>
+    /// <param name="timeout">value to convert</param>
+    /// <returns>
+    /// time in milliseconds as NUMERIC type if less than maximum value of NUMERIC;
+    /// otherwise, maximum value 
+    /// </returns>
+    template <typename NUMERIC, class REP, class PERIOD>
+    [[nodiscard]]
+    constexpr auto to_numeric_milliseconds(std::chrono::duration<REP, PERIOD> const& timeout) -> NUMERIC
     {
-        // same as std::chrono::millisecond::rep, done to show it can be done this way
-        using millisecond_rep = decltype(std::declval<std::chrono::milliseconds>().count());
-        return std::chrono::duration<millisecond_rep>(INFINITE);
-    }
-
-    template <typename NUMERIC>
-    constexpr auto as(std::chrono::milliseconds const& timeout) -> NUMERIC
-    {
-        static_assert(std::is_arithmetic<NUMERIC>::value);
+        static_assert(std::is_arithmetic_v<NUMERIC>);
 
         using std::chrono::milliseconds;
         using millisecond_rep = decltype(std::declval<milliseconds>().count());
         // extra set of () around std::numeric_limits<>::max to circumvent windows max macro
-        return timeout > milliseconds(static_cast<millisecond_rep>((std::numeric_limits<NUMERIC>::max)()))
+        using modern_win32::shared::to_milliseconds;
+
+        return to_milliseconds(timeout) > milliseconds(static_cast<millisecond_rep>((std::numeric_limits<NUMERIC>::max)()))
             ? (std::numeric_limits<NUMERIC>::max)()
             : static_cast<NUMERIC>(timeout.count());
     }
@@ -80,35 +93,190 @@ namespace modern_win32
     }
     constexpr void add_to_array(HANDLE *){}
 
-    template <typename HANDLE>
+    /// <summary>
+    /// wait for the provided handle to be signaled or optional interval to be reached
+    /// </summary>
+    /// <typeparam name="HANDLE"></typeparam>
+    /// <typeparam name="REP">
+    /// an arithmetic type representing the number of ticks
+    /// </typeparam>
+    /// <typeparam name="PERIOD">
+    /// Period (until C++17)typename Period::type (since C++17), a std::ratio
+    /// representing the tick period (i.e. the number of seconds per tick)
+    /// </typeparam>
+    /// <param name="handle"></param>
+    /// <param name="timeout">
+    /// optional internal to wait for, if std::nullopt wait
+    /// will only return when the handle is signaled
+    /// </param>
+    /// <param name="alertable">
+    /// If this parameter is true and the thread is in the waiting state, the
+    /// function returns when the system queues an I/O completion routine or
+    /// APC, and the thread runs the routine or function. Otherwise, the
+    /// function does not return, and the completion routine or APC function
+    /// is not executed.
+    /// </param>
+    /// <returns>wait_for_result containing detials on how the wait was stopped</returns>
+    template <typename HANDLE, class REP = long long, class PERIOD = std::milli>
     [[nodiscard]]
-    auto wait_one(HANDLE const& handle, std::chrono::milliseconds const& timeout = get_infinity_in_ms(), bool const alertable = false) noexcept -> wait_for_result
+    auto wait_one(HANDLE const& handle, std::optional<std::chrono::duration<REP, PERIOD>> const& timeout = std::nullopt, bool const alertable = false) noexcept -> wait_for_result
     {
-        return to_wait_for_result(WaitForSingleObjectEx(handle.native_handle(), as<DWORD>(timeout), alertable ? TRUE : FALSE));
+        using modern_win32::shared::to_milliseconds;
+
+        auto const timeout_value = timeout.has_value()
+            ? to_numeric_milliseconds<DWORD>(timeout.value())
+            : INFINITE;
+
+        return to_wait_for_result(WaitForSingleObjectEx(
+            handle.native_handle(),
+            timeout_value,
+            alertable ? TRUE : FALSE));
     }
 
-    template <typename... HANDLES>
+    /// <summary>
+    /// wait for the provided handle to be signaled or optional interval to be reached
+    /// </summary>
+    /// <typeparam name="HANDLE"></typeparam>
+    /// <typeparam name="REP">
+    /// an arithmetic type representing the number of ticks
+    /// </typeparam>
+    /// <typeparam name="PERIOD">
+    /// Period (until C++17)typename Period::type (since C++17), a std::ratio
+    /// representing the tick period (i.e. the number of seconds per tick)
+    /// </typeparam>
+    /// <param name="handle"></param>
+    /// <param name="timeout">
+    /// optional internal to wait for, if std::nullopt wait
+    /// will only return when the handle is signaled
+    /// </param>
+    /// <param name="alertable">
+    /// If this parameter is true and the thread is in the waiting state, the
+    /// function returns when the system queues an I/O completion routine or
+    /// APC, and the thread runs the routine or function. Otherwise, the
+    /// function does not return, and the completion routine or APC function
+    /// is not executed.
+    /// </param>
+    /// <returns>wait_for_result containing detials on how the wait was stopped</returns>
+    template <typename HANDLE, class REP = long long, class PERIOD = std::milli>
     [[nodiscard]]
-    auto wait_all(HANDLES const & ... args, std::chrono::milliseconds const& timeout = get_infinity_in_ms(), bool const alertable = false) noexcept -> wait_for_result
+    auto wait_one(HANDLE const& handle, std::chrono::duration<REP, PERIOD> const& timeout, bool const alertable = false) noexcept -> wait_for_result
     {
+        return wait_one(handle, std::optional(timeout), alertable);
+    }
+
+    /// <summary>
+    /// wait for all of the provided handles to be signaled or optional interval to be reached
+    /// </summary>
+    /// <typeparam name="...HANDLES"></typeparam>
+    /// <typeparam name="REP">
+    /// an arithmetic type representing the number of ticks
+    /// </typeparam>
+    /// <typeparam name="PERIOD">
+    /// Period (until C++17)typename Period::type (since C++17), a std::ratio
+    /// representing the tick period (i.e. the number of seconds per tick)
+    /// </typeparam>
+    /// <param name="args"></param>
+    /// <param name="timeout">
+    /// optional internal to wait for, if std::nullopt wait
+    /// will only return when all handles are signaled
+    /// </param>
+    /// <param name="alertable">
+    /// If this parameter is true and the thread is in the waiting state, the
+    /// function returns when the system queues an I/O completion routine or
+    /// APC, and the thread runs the routine or function. Otherwise, the
+    /// function does not return, and the completion routine or APC function
+    /// is not executed.
+    /// </param>
+    /// <returns>wait_for_result containing detials on how the wait was stopped</returns>
+    template <typename... HANDLES, class REP = long long, class PERIOD = std::milli>
+    [[nodiscard]]
+    auto wait_all(HANDLES const & ... args, std::optional<std::chrono::duration<REP, PERIOD>> const& timeout, bool const alertable = false) noexcept -> wait_for_result
+    {
+        auto const timeout_value = timeout.has_value()
+            ? to_numeric_milliseconds<DWORD>(timeout.value())
+            : INFINITE;
         static_assert(sizeof...(HANDLES) < static_cast<size_t>(MAXIMUM_WAIT_OBJECTS));
         HANDLE handles[sizeof...(HANDLES)];
         add_to_array(handles, args...);
-        return to_wait_for_result(WaitForMultipleObjectsEx(sizeof...(HANDLES), handles, true, as<DWORD>(timeout), alertable ? TRUE : FALSE));
+        return to_wait_for_result(WaitForMultipleObjectsEx(
+            sizeof...(HANDLES),
+            handles, true,
+            timeout_value,
+            alertable ? TRUE : FALSE));
     }
 
-    template <typename... HANDLES>
+    /// <summary>
+    /// wait for all of the provided handles to be signaled or optional interval to be reached
+    /// </summary>
+    /// <typeparam name="...HANDLES"></typeparam>
+    /// <typeparam name="REP">
+    /// an arithmetic type representing the number of ticks
+    /// </typeparam>
+    /// <typeparam name="PERIOD">
+    /// Period (until C++17)typename Period::type (since C++17), a std::ratio
+    /// representing the tick period (i.e. the number of seconds per tick)
+    /// </typeparam>
+    /// <param name="args"></param>
+    /// <param name="timeout">
+    /// optional internal to wait for, if std::nullopt wait
+    /// will only return when all handles are signaled
+    /// </param>
+    /// <param name="alertable">
+    /// If this parameter is true and the thread is in the waiting state, the
+    /// function returns when the system queues an I/O completion routine or
+    /// APC, and the thread runs the routine or function. Otherwise, the
+    /// function does not return, and the completion routine or APC function
+    /// is not executed.
+    /// </param>
+    /// <returns>wait_for_result containing detials on how the wait was stopped</returns>
+    template <typename... HANDLES, class REP = long long, class PERIOD = std::milli>
     [[nodiscard]]
-    auto wait_any(HANDLES const & ... args, std::chrono::milliseconds const& timeout = get_infinity_in_ms(), bool const alertable = false) noexcept -> std::tuple<wait_for_result, std::optional<HANDLE>>
+    auto wait_all(HANDLES const & ... args, std::chrono::duration<REP, PERIOD> const& timeout, bool const alertable = false) noexcept -> wait_for_result
     {
+        return wait_all(args, std::optional(timeout), alertable);
+    }
+
+    /// <summary>
+    /// wait for any of the provided handles to be signaled or optional interval to be reached
+    /// </summary>
+    /// <typeparam name="...HANDLES"></typeparam>
+    /// <typeparam name="REP">
+    /// an arithmetic type representing the number of ticks
+    /// </typeparam>
+    /// <typeparam name="PERIOD">
+    /// Period (until C++17)typename Period::type (since C++17), a std::ratio
+    /// representing the tick period (i.e. the number of seconds per tick)
+    /// </typeparam>
+    /// <param name="args">compile time array of HANDLE objects to be waited on</param>
+    /// <param name="timeout">
+    /// optional internal to wait for, if std::nullopt wait
+    /// will only return when any handle is signaled
+    /// </param>
+    /// <param name="alertable">
+    /// If this parameter is true and the thread is in the waiting state, the
+    /// function returns when the system queues an I/O completion routine or
+    /// APC, and the thread runs the routine or function. Otherwise, the
+    /// function does not return, and the completion routine or APC function
+    /// is not executed.
+    /// </param>
+    /// <returns>wait_for_result containing detials on how the wait was stopped</returns>
+    template <typename... HANDLES, class REP = long long, class PERIOD = std::milli>
+    [[nodiscard]]
+    auto wait_any(HANDLES const & ... args, std::optional<std::chrono::duration<REP, PERIOD>> const& timeout = std::nullopt, bool const alertable = false) noexcept -> std::tuple<wait_for_result, std::optional<HANDLE>>
+    {
+        using modern_win32::shared::to_milliseconds;
+
+        auto const timeout_value = timeout.has_value()
+            ? to_numeric_milliseconds<DWORD>(to_milliseconds(timeout.value()))
+            : INFINITE;
+
         static_assert(sizeof...(HANDLES) < static_cast<size_t>(MAXIMUM_WAIT_OBJECTS));
         HANDLE handles[sizeof...(HANDLES)];
         add_to_array(handles, args...);
 
-        auto const native_result = WaitForMultipleObjectsEx(sizeof...(HANDLES), handles, false, as<DWORD>(timeout), alertable ? TRUE : FALSE);
-        auto const result = to_wait_for_result(native_result);
+        auto const native_result = WaitForMultipleObjectsEx(sizeof...(HANDLES), handles, false, timeout_value, alertable ? TRUE : FALSE);
 
-        switch (result) {
+        switch (auto const result = to_wait_for_result(native_result)) {
         case wait_for_result::object:
             if (auto const index = native_result - WAIT_OBJECT_0;
                 index >= 0 && index < sizeof...(HANDLES)) {
@@ -124,6 +292,37 @@ namespace modern_win32
         default:
             return std::make_tuple(result, std::nullopt);
         }
+    }
+
+    /// <summary>
+    /// wait for any of the provided handles to be signaled or optional interval to be reached
+    /// </summary>
+    /// <typeparam name="...HANDLES"></typeparam>
+    /// <typeparam name="REP">
+    /// an arithmetic type representing the number of ticks
+    /// </typeparam>
+    /// <typeparam name="PERIOD">
+    /// Period (until C++17)typename Period::type (since C++17), a std::ratio
+    /// representing the tick period (i.e. the number of seconds per tick)
+    /// </typeparam>
+    /// <param name="args">compile time array of HANDLE objects to be waited on</param>
+    /// <param name="timeout">
+    /// optional internal to wait for, if std::nullopt wait
+    /// will only return when any handle is signaled
+    /// </param>
+    /// <param name="alertable">
+    /// If this parameter is true and the thread is in the waiting state, the
+    /// function returns when the system queues an I/O completion routine or
+    /// APC, and the thread runs the routine or function. Otherwise, the
+    /// function does not return, and the completion routine or APC function
+    /// is not executed.
+    /// </param>
+    /// <returns>wait_for_result containing detials on how the wait was stopped</returns>
+    template <typename... HANDLES, class REP = long long, class PERIOD = std::milli>
+    [[nodiscard]]
+    auto wait_any(HANDLES const & ... args, std::chrono::duration<REP, PERIOD> const& timeout = std::nullopt, bool const alertable = false) noexcept -> std::tuple<wait_for_result, std::optional<HANDLE>>
+    {
+        return wait_any(args, std::optional(timeout), alertable);
     }
 
     /// <summary>

--- a/src/modern_win32/CMakeLists.txt
+++ b/src/modern_win32/CMakeLists.txt
@@ -39,6 +39,7 @@ set (PUBLIC_HEADER_FILES
     "../../include/modern_win32/shared_utilities.h"
     "../../include/modern_win32/string.h"
     "../../include/modern_win32/shared/case_insensitive_string.h"
+    "../../include/modern_win32/shared/chrono_extensions.h"
     "../../include/modern_win32/shared/timed_lock_guard.h"
     "../../include/modern_win32/shared/timeout_exception.h"
     "../../include/modern_win32/threading/slim_lock.h"

--- a/src/modern_win32/environment.cpp
+++ b/src/modern_win32/environment.cpp
@@ -1,5 +1,5 @@
 //
-// Copyright © 2020 Terry Moreland
+// Copyright Â© 2020 Terry Moreland
 // Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), 
 // to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, 
 // and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
@@ -66,7 +66,7 @@ bool try_get_all_environment_variables(environment_map<char>& environment)
 #   undef GetEnvironmentStrings
     auto deleter = [](char*& character) { FreeEnvironmentStringsA(character); };
     auto const env_block = std::unique_ptr<char, decltype(deleter)>{GetEnvironmentStrings(), deleter};
-#   define GetEnvironmentStrings GetEnvironmentStringsW  // NOLINT(cppcoreguidelines-macro-usage) -- re-enabling GetEnvironmentStrings macro
+#   define GetEnvironmentStrings GetEnvironmentStringsW  // NOLINT(cppcoreguidelines-macro-usage, clang-diagnostic-unused-macros) -- re-enabling GetEnvironmentStrings macro
 #   else 
     auto deleter = [](char* character) { FreeEnvironmentStringsA(character); };
     auto env_block = std::unique_ptr<char, decltype(free)>{GetEnvironmentStrings(), deleter};
@@ -81,7 +81,7 @@ bool try_get_all_environment_variables(environment_map<char>& environment)
 }
 
 template <>
-bool try_get_all_environment_variables(environment_map<wchar_t>& environment)
+bool try_get_all_environment_variables(environment_map<wchar_t>&)
 {
     auto deleter = [](wchar_t*& character) { FreeEnvironmentStringsW(character); };
     auto const env_block = std::unique_ptr<wchar_t, decltype(deleter)>{GetEnvironmentStringsW(), deleter};

--- a/src/modern_win32/wait_for.cpp
+++ b/src/modern_win32/wait_for.cpp
@@ -26,9 +26,12 @@ bool is_complete(wait_for_result const& result)
         throw std::runtime_error("unexpected handle type");
     case wait_for_result::failed:
         throw windows_exception();
-    default:
+    case wait_for_result::io_completion:
+    case wait_for_result::timeout:
         return false;
     }
+
+    return false;
 }
 
 }

--- a/src/modern_win32/wait_for.cpp
+++ b/src/modern_win32/wait_for.cpp
@@ -12,6 +12,7 @@
 // 
 
 #include <modern_win32/wait_for.h>
+#include <modern_win32/windows_exception.h>
 
 namespace modern_win32
 {

--- a/tests/modern_win32_test/context.h
+++ b/tests/modern_win32_test/context.h
@@ -70,7 +70,7 @@ namespace modern_win32::test
             signaled = event.wait_one(); 
             EXPECT_TRUE(signaled);
 
-            return event.wait_one(std::chrono::milliseconds(50));
+            return event.wait_one(std::optional(std::chrono::milliseconds(50)));
         }
 
         [[nodiscard]]


### PR DESCRIPTION
## Changes
- tweaked so it no longer takes ```std::chrono::milliseconds``` and takes templated duration instead, 
- updated so it takes an optional defaulting to ```std::nullopt```
- added overload taking duration so we don't have to add the optional part